### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ It mainly relies on [AFNetworking](https://github.com/AFNetworking/AFNetworking)
 # Installation
 **XBToolkit** can be installed through [CocoaPods](http://cocoapods.org) or by including the source files into  your project.
 
-If you use Cocoapods, please install XBToolkit by appending to your Podfile the following line :
+If you use CocoaPods, please install XBToolkit by appending to your Podfile the following line :
 
 	pod XBToolkit
 


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
